### PR TITLE
feat: target_version support , riscv_common_function_versions and riscv_compare_version_priority.

### DIFF
--- a/gcc/config/riscv/riscv-protos.h
+++ b/gcc/config/riscv/riscv-protos.h
@@ -799,6 +799,10 @@ extern bool
 riscv_option_valid_version_attribute_p (tree, tree, tree, int);
 extern bool
 riscv_process_target_attr(const char *, location_t);
+extern bool
+riscv_common_function_versions (tree, tree);
+extern int
+riscv_compare_version_priority (tree, tree);
 extern void
 riscv_override_options_internal (struct gcc_options *);
 extern void riscv_option_override (void);

--- a/gcc/config/riscv/riscv-target-attr.cc
+++ b/gcc/config/riscv/riscv-target-attr.cc
@@ -29,7 +29,11 @@ along with GCC; see the file COPYING3.  If not see
 #include "tm_p.h"
 #include "diagnostic.h"
 #include "opts.h"
+#include "stringpool.h"
+#include "attribs.h"
 #include "riscv-subset.h"
+
+//#include "common/config/riscv/feature_bits.h"
 
 namespace {
 class riscv_target_attr_parser
@@ -51,6 +55,7 @@ public:
   bool handle_tune (const char *);
 
   void update_settings (struct gcc_options *opts) const;
+  riscv_subset_list *get_subset_list();
 private:
   const char *m_raw_attr_str;
   bool parse_arch (const char *);
@@ -238,11 +243,16 @@ riscv_target_attr_parser::update_settings (struct gcc_options *opts) const
     }
 }
 
+riscv_subset_list*
+riscv_target_attr_parser::get_subset_list()
+{
+  return m_subset_list;
+}
 /* Parse ARG_STR which contains the definition of one target attribute.
    Show appropriate errors if any or return true if the attribute is valid.  */
 
 static bool
-riscv_process_one_target_attr (char *arg_str,
+riscv_process_one_target_attr (const char *arg_str,
 			       location_t loc,
 			       riscv_target_attr_parser &attr_parser)
 {
@@ -449,13 +459,305 @@ riscv_option_valid_attribute_p (tree fndecl, tree, tree args, int)
   return ret;
 }
 
+/* Parse function multiversioning arch string, use the riscv_target_attr_parser
+   to update information. */
+
+static bool
+riscv_parse_fmv_features (const char *str, location_t loc) 
+{
+  if (strcmp (str, "default") == 0)
+    return true;
+  
+  riscv_target_attr_parser attr_parser (loc);
+  if (!riscv_process_one_target_attr (str, loc, attr_parser))
+    return false;
+  
+  attr_parser.update_settings (&global_options);
+  return true;
+  
+}
+
+/* Parse the tree in ARGS that contains the target_version attribute
+   information and update the global target options space.  */
+
+static bool
+riscv_process_target_version_attr (tree args, location_t loc)
+{
+  if (TREE_CODE (args) == TREE_LIST)
+    {
+      if (TREE_CHAIN (args))
+        {
+          error ("attribute %<target_version%> has multiple values");
+          return false;
+        }
+      args = TREE_VALUE (args);
+    }
+
+  if (!args || TREE_CODE (args) != STRING_CST)
+    {
+      error ("attribute %<target_version%> argument not a string");
+      return false;
+    }
+  const char *str = TREE_STRING_POINTER (args);
+  bool parse_res = riscv_parse_fmv_features (str, loc);
+
+  return parse_res;
+}
+
+
 /* Implement TARGET_OPTION_VALID_VERSION_ATTRIBUTE_P.  This is used to
    process attribute ((target_version ("..."))).  */
 
 bool
 riscv_option_valid_version_attribute_p (tree fndecl, tree, tree args, int)
 {
-  fprintf(stderr, "Unimplemented riscv_option_valid_version_attribute_p\n");
-  gcc_unreachable (); // TODO
-  return false;
+  //gcc_unreachable (); // TODO
+  struct cl_target_option cur_target;
+  bool ret;
+  tree new_target;
+  tree existing_target = DECL_FUNCTION_SPECIFIC_TARGET (fndecl);
+  location_t loc = DECL_SOURCE_LOCATION (fndecl);
+
+  /* Save the current target options to restore at the end.  */
+  cl_target_option_save (&cur_target, &global_options, &global_options_set);
+
+  /* If fndecl already has some target attributes applied to it, unpack
+     them so that we add this attribute on top of them, rather than
+     overwriting them.  */
+  if (existing_target)
+    {    
+      struct cl_target_option *existing_options
+        = TREE_TARGET_OPTION (existing_target);
+
+      if (existing_options)
+        cl_target_option_restore (&global_options, &global_options_set,
+                                  existing_options);
+    }    
+  else
+    cl_target_option_restore (&global_options, &global_options_set,
+                              TREE_TARGET_OPTION (target_option_current_node));
+
+  ret = riscv_process_target_version_attr (args, loc);
+
+  /* Set up any additional state.  */
+  if (ret)
+    {
+      riscv_override_options_internal (&global_options);
+      new_target = build_target_option_node (&global_options,
+                                             &global_options_set);
+    }
+  else
+    new_target = NULL;
+
+  if (fndecl && ret)
+      DECL_FUNCTION_SPECIFIC_TARGET (fndecl) = new_target;
+  
+  cl_target_option_restore (&global_options, &global_options_set, &cur_target);
+
+  return ret;
 }
+
+/* Types for recording extension to RISC-V C-API bitmask.  */
+struct riscv_ext_bitmask_table_t {
+  const char *ext;
+  int groupid;
+  int bit_position;
+};
+
+static const riscv_ext_bitmask_table_t riscv_ext_bitmask_table[] =
+{
+  {"i",                 0,  8},
+  {"m",                 0, 12},
+  {"a",                 0,  0},
+  {"f",                 0,  5},
+  {"d",                 0,  3},
+  {"c",                 0,  2},
+  {"v",                 0, 21},
+  {"zba",               0, 27},
+  {"zbb",               0, 28},
+  {"zbs",               0, 33},
+  {"zicboz",            0, 37},
+  {"zbc",               0, 29},
+  {"zbkb",              0, 30},
+  {"zbkc",              0, 31},
+  {"zbkx",              0, 32},
+  {"zknd",              0, 41},
+  {"zkne",              0, 42},
+  {"zknh",              0, 43},
+  {"zksed",             0, 44},
+  {"zksh",              0, 45},
+  {"zkt",               0, 46},
+  {"zvbb",              0, 48},
+  {"zvbc",              0, 49},
+  {"zvkb",              0, 52},
+  {"zvkg",              0, 53},
+  {"zvkned",            0, 54},
+  {"zvknha",            0, 55},
+  {"zvknhb",            0, 56},
+  {"zvksed",            0, 57},
+  {"zvksh",             0, 58},
+  {"zvkt",              0, 59},
+  {"zfh",               0, 35},
+  {"zfhmin",            0, 36},
+  {"zihintntl",         0, 39},
+  {"zvfh",              0, 50},
+  {"zvfhmin",           0, 51},
+  {"zfa",               0, 34},
+  {"ztso",              0, 47},
+  {"zacas",             0, 26},
+  {"zicond",            0, 38},
+  {"zihintpause",       0, 40},
+  {"zve32x",            0, 60},
+  {"zve32f",            0, 61},
+  {"zve64x",            0, 62},
+  {"zve64f",            0, 63},
+  {"zve64d",            1,  0},
+  {"zimop",             1,  1},
+  {"zca",               1,  2},
+  {"zcb",               1,  3},
+  {"zcd",               1,  4},
+  {"zcf",               1,  5},
+  {"zcmop",             1,  6},
+  {"zawrs",             1,  7},
+  {NULL,               -1, -1}
+};
+
+/* Parse a function multiversioning feature string STR, as found in a
+   target_version or target_clones attribute. */
+
+static bool
+parse_feature_bits (const char *str, struct riscv_feature_bits *res)
+{
+  //fprintf (stderr, "parse_feature_bits string is %s.\n", str);
+  riscv_subset_list *subset_list;
+
+  if (strcmp (str, "default") == 0) {
+    res->length = 0;
+    res->features[1] = 0;
+    res->features[0] = 0;
+    return true;
+  }
+
+  riscv_target_attr_parser attr_parser (UNKNOWN_LOCATION);
+  if (!riscv_process_one_target_attr (str, UNKNOWN_LOCATION, attr_parser))
+    return false;
+
+  subset_list = attr_parser.get_subset_list();
+
+  if (!subset_list)
+    return false;
+
+  res->length = RISCV_FEATURE_BITS_LENGTH;
+  for (int i = 0; i < RISCV_FEATURE_BITS_LENGTH; ++i)
+    res->features[i] = 0;
+
+  const struct riscv_ext_bitmask_table_t *ext_bitmask_tab;
+  for (ext_bitmask_tab = &riscv_ext_bitmask_table[0];
+       ext_bitmask_tab->ext;
+       ++ext_bitmask_tab)
+    {
+      if (subset_list->lookup (ext_bitmask_tab->ext) == NULL)
+        continue;
+
+      res->features[ext_bitmask_tab->groupid]
+        |= 1ULL << ext_bitmask_tab->bit_position;
+    }
+
+  return true;
+}
+
+/* Compare priorities of two feature masks. Return:
+     1: mask1 is higher priority
+    -1: mask2 is higher priority
+     0: masks are equal. 
+   Since riscv_feature_bits has total 128 bits to be used as mask, 
+   when counting the total 1s in the mask, the 1s in group1 needs to multiply a weight. */
+
+static int
+compare_feature_masks (struct riscv_feature_bits mask1,
+                       struct riscv_feature_bits mask2)
+{
+  fprintf (stderr, "compare_feature_mask.\n");
+  int pop1, pop2;
+  int length1 = mask1.length, length2 = mask2.length;
+
+  if (length1 > length2)
+    return 1;
+  else if (length1 < length2)
+    return -1;
+  else{
+    pop1 = (popcount_hwi (mask1.features[length1 - 1]) * 64) + popcount_hwi (mask1.features[length1 - 2]);
+    pop2 = (popcount_hwi (mask2.features[length2 - 1]) * 64) + popcount_hwi (mask2.features[length2 - 2]);
+    //fprintf (stderr, "compare_feature_mask2 pop1 = %d, pop2 = %d.\n", pop1, pop2);
+    if (pop1 > pop2)
+      return 1;
+    if (pop1 < pop2)
+      return -1;
+    auto diff_mask_group1 = mask1.features[1] ^ mask2.features[1];
+    auto diff_mask_group0 = mask1.features[0] ^ mask2.features[0];
+    if (diff_mask_group1 == 0ULL && diff_mask_group0 == 0ULL)
+      return 0;
+    else
+      return 1;
+  }
+}
+
+/* This parses the attribute arguments to target_version in DECL and the
+   feature mask required to select those targets.  */
+
+static struct riscv_feature_bits
+get_feature_mask_for_version (tree decl)
+{
+  tree version_attr = lookup_attribute ("target_version",
+                                        DECL_ATTRIBUTES (decl));
+  struct riscv_feature_bits res;
+  if (version_attr == NULL) {
+    res.length = 0;
+    res.features[0] = 0;
+    res.features[1] = 0;
+    return res;
+  }
+ 
+  const char *version_string = TREE_STRING_POINTER (TREE_VALUE (TREE_VALUE
+                                                    (version_attr)));
+  
+  bool parse_res = parse_feature_bits (version_string, &res);
+
+  gcc_assert (parse_res == true);
+
+  return res;
+}
+
+/* Compare priorities of two version decls. Return:
+     1: mask1 is higher priority
+    -1: mask2 is higher priority
+     0: masks are equal.  */
+
+int
+riscv_compare_version_priority (tree decl1, tree decl2)
+{
+  fprintf(stderr, "riscv_compare_version_priority\n");
+  //gcc_unreachable ();
+  struct riscv_feature_bits mask1 = get_feature_mask_for_version (decl1);
+  struct riscv_feature_bits mask2 = get_feature_mask_for_version (decl2);
+
+  return compare_feature_masks (mask1, mask2);
+}
+
+/* This function returns true if FN1 and FN2 are versions of the same function,
+   that is, the target_version attributes of the function decls are different.
+   This assumes that FN1 and FN2 have the same signature. */
+
+bool
+riscv_common_function_versions (tree fn1, tree fn2)
+{
+  if (TREE_CODE (fn1) != FUNCTION_DECL
+      || TREE_CODE (fn2) != FUNCTION_DECL)
+    return false;
+
+  fprintf(stderr, "riscv_common_function_versions\n");
+
+  return false; // TODO: return (riscv_compare_version_priority (fn1, fn2) != 0);
+  //return (riscv_compare_version_priority (fn1, fn2) != 0);
+}
+

--- a/gcc/config/riscv/riscv.h
+++ b/gcc/config/riscv/riscv.h
@@ -1260,6 +1260,9 @@ extern void riscv_remove_unneeded_save_restore_calls (void);
 #define HAVE_POST_MODIFY_DISP TARGET_XTHEADMEMIDX
 #define HAVE_PRE_MODIFY_DISP  TARGET_XTHEADMEMIDX
 
+/* Hank Add */
+#define TARGET_HAS_FMV_TARGET_ATTRIBUTE 0
+
 /* Check TLS Descriptors mechanism is selected.  */
 #define TARGET_TLSDESC (riscv_tls_dialect == TLS_DESCRIPTORS)
 


### PR DESCRIPTION
This patch implements:
-TARGET_OPTION_VALID_VERSION_ATTRIBUTE_P
-TARGET_OPTION_FUNCTION_VERSIONS
-TARGET_COMPARE_VERSION_PRIORITY

Currently target_version can be parsed, and come up with the basic implementation of riscv_common_function_version and riscv_compare_version_priority to allow the multi-versioned function to be generated.

For the TARGET_OPTION_VALID_VERSION_ATTRIBUTE_P, I implement a function parse_fmv to deal with the arch string passed by target_version.

For the TARGET_OPTION_FUNCTION_VERSIONS, I implement a function get_feature_bits to parse the feature mask of two decls and send it to do the priority comparison.

For the TARGET_COMPARE_VERSION_PRIORITY, I implement a function compare_feature_masks to do the comparison between two decls.

Aware : some error will occur in the testsuite stage when building this gcc, the main problem I haven't checked yet. I think it is related to generating dispatcher function. But it can still make install and test. Need to find out why this error occurs.

Thanks for taking the time to contribute to GCC! Please be advised that if you are
viewing this on `github.com`, that the mirror there is unofficial and unmonitored.
The GCC community does not use `github.com` for their contributions. Instead, we use
a mailing list (`gcc-patches@gcc.gnu.org`) for code submissions, code reviews, and
bug reports. Please send patches there instead.
